### PR TITLE
Fix typo on reset databrowser logindate.

### DIFF
--- a/webapps/assets/core/newdefaultfilter.js
+++ b/webapps/assets/core/newdefaultfilter.js
@@ -375,7 +375,7 @@ var resetFilter = function(){
 	filters.inputIRRangeVal("")
 	filters.dataRating("")
 
-	fitlers.loginDateVal("")
+	filters.loginDateVal("")
 }
 
 var showMoreFilter = function(){


### PR DESCRIPTION
Typo makes logindate filter not cleared at reset.